### PR TITLE
Add test case to demonstrate exception on pickling RethrownJobError

### DIFF
--- a/ruffus/test/test_exceptions.py
+++ b/ruffus/test/test_exceptions.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 import os
 import sys
+import logging
 
 # add grandparent to search path for testing
 grandparent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -21,9 +22,22 @@ module_name = os.path.splitext(os.path.basename(__file__))[0]
 # funky code to import by file name
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 import ruffus
-from ruffus import pipeline_run, pipeline_printout, Pipeline, parallel
+from ruffus import pipeline_run, pipeline_printout, Pipeline, parallel, proxy_logger
 
 
+def logging_factory(logger_name, listargs):
+    root_logger = logging.getLogger(logger_name)
+    root_logger.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler(sys.stderr)
+    formatter_ = logging.Formatter("%(levelname)7s - %(message)s")
+    handler.setFormatter(formatter_)
+    handler.setLevel(logging.INFO)
+    root_logger.addHandler(handler)
+    return root_logger
+
+log, log_mutex = proxy_logger.make_shared_logger_and_proxy(
+    logging_factory, __name__, [])
 
 
 #88888888888888888888888888888888888888888888888888888888888888888888888888888888888888888
@@ -37,7 +51,8 @@ from ruffus import pipeline_run, pipeline_printout, Pipeline, parallel
 def parallel_task(name, param1):
     sys.stderr.write("    Parallel task %s: \n" % name)
     #raise task.JobSignalledBreak("Oops! I did it again!")
-    print ("    Raising exception", file = sys.stderr)
+    with log_mutex:
+        log.info("    Raising exception")
     raise Exception("new")
 
 
@@ -52,6 +67,17 @@ class Test_ruffus(unittest.TestCase):
         try:
             pipeline_run(multiprocess = 50, verbose = 0, pipeline= "main")
         except ruffus.ruffus_exceptions.RethrownJobError:
+            return
+        raise Exception("Missing exception")
+
+    def test_exception_logging(self):
+        try:
+            pipeline_run(multiprocess = 50, verbose = 0, pipeline= "main")
+        except ruffus.ruffus_exceptions.RethrownJobError as e:
+            log.info(e)
+            for exc in e.args:
+                task_name, job_name, exc_name, exc_value, exc_stack = exc
+            log.join()
             return
         raise Exception("Missing exception")
 


### PR DESCRIPTION
Here's your test case. Checked in Python 3.5.1 in a virtual environment that contained only ruffus.

At least one problem here is that because of the non-standard exception arguments, `RethrownJobError` cannot be de-pickled, because `BaseException` in CPython defines a custom `__reduce__()` that contains certain assumptions including that there is a tuple args and it will create the new exception by invoking `CustomException.__init__(*args)`. After that all other variables are set.

I think `error_task_construction` and its subclasses will have similar problems too, but `error_task` is probably okay.

Exceptions have to be picklable to cross process boundaries. One demonstration of this is attempting to log the exception using the ruffus proxy_logger since it puts the logging in a separate process. This doesn't exactly replicate the error I was getting, although I did find a more complex way to do that. I will check for that if necessary, but I suspect getting RethrownJobError to unpickle properly will resolve the issue (and it should be resolved regardless).

See here for some details and a link to the relevant C code for `BaseException.__reduce__`
https://stackoverflow.com/questions/16244923/how-to-make-a-custom-exception-class-with-multiple-init-args-pickleable